### PR TITLE
[bugfix] Adding a missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ldap3
+impacket


### PR DESCRIPTION
Hello,

This PR adds the `impacket` dependency that is missing to make the tool work.